### PR TITLE
Refactor + unit tests + `required` function

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - 386
       - amd64
     ldflags:
-      - -s -w -X github.com/julienbreux/clamp/cmd.version={{.Version}} -X github.com/julienbreux/clamp/cmd.commit={{.Commit}} -X github.com/julienbreux/clamp/cmd.date={{.Date}}
+      - -s -w -X github.com/julienbreux/clamp/version.Version={{.Version}} -X github.com/julienbreux/clamp/version.Commit={{.Commit}} -X github.com/julienbreux/clamp/version.Date={{.Date}}
 archives:
   - id: clamp
     format_overrides:

--- a/functions/map.go
+++ b/functions/map.go
@@ -1,0 +1,12 @@
+package functions
+
+import "text/template"
+
+// Map returns a map of functions to use with Go's standard template package.
+func Map() template.FuncMap {
+	fm := make(template.FuncMap)
+
+	fm["required"] = required
+
+	return fm
+}

--- a/functions/required.go
+++ b/functions/required.go
@@ -1,0 +1,14 @@
+package functions
+
+import "errors"
+
+func required(msg string, val interface{}) (interface{}, error) {
+	if val == nil {
+		return val, errors.New(msg)
+	} else if _, ok := val.(string); ok {
+		if val == "" {
+			return val, errors.New(msg)
+		}
+	}
+	return val, nil
+}

--- a/functions/required_test.go
+++ b/functions/required_test.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRequired(t *testing.T) {
+	tests := map[string]struct {
+		msg       string
+		value     interface{}
+		expectErr bool
+	}{
+		// The following values are OK.
+		"false":       {"", false, false},
+		"true":        {"", false, false},
+		"string":      {"", "foo bar baz", false},
+		"slice":       {"", []string{"foo", "bar", "baz"}, false},
+		"empty-slice": {"", []string{}, false},
+		"nil-slice":   {"", []string(nil), false}, // Technically, []string(nil) != nil
+		"integer":     {"", 12345, false},
+		"zero":        {"", 0, false},
+		"map":         {"", map[string]string{"A": "B", "C": "D"}, false},
+		"empty-map":   {"", map[string]string{}, false},
+		"nil-map":     {"", map[string]string(nil), false}, // Technically, []map[string]string(nil) != nil
+		// The following values are NOT OK.
+		"empty-string": {"strings cannot be empty", "", true},
+		"nil-values":   {"values cannot be nil", nil, true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := required(test.msg, test.value)
+
+			if !reflect.DeepEqual(actual, test.value) {
+				t.Errorf("value should not change; expected %v, got %v", test.value, actual)
+			}
+
+			switch {
+			case err == nil && !test.expectErr:
+				// No error expected, no error returned 👌
+			case err == nil && test.expectErr:
+				t.Errorf("expected error, got none")
+			case err != nil && !test.expectErr:
+				t.Errorf("unexpected error: %s", err.Error())
+			case err != nil && test.expectErr:
+				if !strings.Contains(err.Error(), test.msg) {
+					t.Errorf("error should contain message")
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,14 @@ func main() {
 		return
 	}
 
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err.Error())
+	}
+}
+
+func run() error {
 	input()
+	return nil
 }
 
 func input() {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,8 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		printVersion()
+		version.Print()
+		return
 	}
 
 	input()
@@ -85,12 +86,6 @@ func check(e error) {
 	if e != nil {
 		panic(e)
 	}
-}
-
-func printVersion() {
-	fmt.Printf("Clamp version %s build %s (at %s)\n", version.Version, version.Commit, version.Date)
-
-	os.Exit(0)
 }
 
 func printInputErrorMessage() {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	defer in.Close()
 
 	var buf bytes.Buffer
 	if err := transform(&buf, in, envVars()); err != nil {
@@ -54,7 +55,7 @@ func run() error {
 	return nil
 }
 
-func input() (io.Reader, error) {
+func input() (*os.File, error) {
 	switch flag.NArg() {
 	case 0:
 		return os.Stdin, nil

--- a/main.go
+++ b/main.go
@@ -9,14 +9,11 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+	"github.com/julienbreux/clamp/version"
 )
 
 var (
 	showVersion = false
-
-	version = "dev"
-	commit  = "n/a"
-	date    = "n/a"
 )
 
 func init() {
@@ -91,7 +88,7 @@ func check(e error) {
 }
 
 func printVersion() {
-	fmt.Printf("Clamp version %s build %s (at %s)\n", version, commit, date)
+	fmt.Printf("Clamp version %s build %s (at %s)\n", version.Version, version.Commit, version.Date)
 
 	os.Exit(0)
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+	"github.com/julienbreux/clamp/functions"
 	"github.com/julienbreux/clamp/version"
 )
 
@@ -32,7 +33,7 @@ func main() {
 	}
 
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "clamp: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "clamp: %s\n", err.Error())
 	}
 }
 
@@ -80,8 +81,8 @@ func transform(w io.Writer, r io.Reader, vars map[string]string) error {
 	tmpl, err := template.New("default").
 		Option("missingkey=zero").
 		Funcs(sprig.HermeticTxtFuncMap()).
+		Funcs(functions.Map()).
 		Parse(string(data))
-
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -29,45 +32,50 @@ func main() {
 	}
 
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err.Error())
+		fmt.Fprintf(os.Stderr, "clamp: %s", err.Error())
 	}
 }
 
 func run() error {
-	input()
+	in, err := input()
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := transform(&buf, in, envVars()); err != nil {
+		return fmt.Errorf("could not render: %w", err)
+	}
+
+	if _, err := io.Copy(os.Stdout, &buf); err != nil {
+		return fmt.Errorf("could not print: %w", err)
+	}
+
 	return nil
 }
 
-func input() {
-	var data []byte
-	var err error
-
+func input() (io.Reader, error) {
 	switch flag.NArg() {
 	case 0:
-		file := os.Stdin
-		fi, err := file.Stat()
-		check(err)
-		if fi.Size() == 0 {
-			printInputErrorMessage()
-		}
-
-		data, err = ioutil.ReadAll(os.Stdin)
-		check(err)
-		err = transform(data)
-		check(err)
-		break
+		return os.Stdin, nil
 	case 1:
-		data, err = ioutil.ReadFile(flag.Arg(0))
-		check(err)
-		err = transform(data)
-		check(err)
-		break
+		filename := flag.Arg(0)
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open %q: %w", filename, err)
+		}
+		return f, nil
 	default:
-		printInputErrorMessage()
+		return nil, errors.New("incorrect usage: too many arguments")
 	}
 }
 
-func transform(data []byte) error {
+func transform(w io.Writer, r io.Reader, vars map[string]string) error {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("input is unreadable: %w", err)
+	}
+
 	tmpl, err := template.New("default").
 		Option("missingkey=zero").
 		Funcs(sprig.HermeticTxtFuncMap()).
@@ -77,7 +85,7 @@ func transform(data []byte) error {
 		return err
 	}
 
-	return tmpl.Execute(os.Stdout, envVars())
+	return tmpl.Execute(w, vars)
 }
 
 func envVars() map[string]string {
@@ -87,16 +95,4 @@ func envVars() map[string]string {
 		vars[pair[0]] = pair[1]
 	}
 	return vars
-}
-
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
-
-func printInputErrorMessage() {
-	fmt.Printf("Input must be from stdin or file and non empty\n")
-
-	os.Exit(1)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTransform(t *testing.T) {
+	tests := map[string]struct {
+		vars      map[string]string
+		input     string
+		output    string
+		expectErr bool
+	}{
+		"simple": {
+			vars:      map[string]string{"FOO": "BAR", "BAZ": "QLUX"},
+			input:     "FOO={{ .FOO }}, BAZ={{ .BAZ }}",
+			output:    "FOO=BAR, BAZ=QLUX",
+			expectErr: false,
+		},
+		"missing-var": {
+			vars:      map[string]string{"FOO": "BAR"},
+			input:     `FOO={{ .FOO }}, BAZ={{ .BAZ }}`,
+			output:    `FOO=BAR, BAZ=`,
+			expectErr: false,
+		},
+		"required-and-present": {
+			vars:      map[string]string{"FOO": "BAR", "BAZ": "QLUX"},
+			input:     `FOO={{ .FOO }}, BAZ={{ required "BAZ must be set" .BAZ }}`,
+			output:    `FOO=BAR, BAZ=QLUX`,
+			expectErr: false,
+		},
+		"required-and-missing": {
+			vars:      map[string]string{"FOO": "BAR"},
+			input:     `FOO={{ .FOO }}, BAZ={{ required "BAZ must be set" .BAZ }}`,
+			output:    `FOO=BAR, BAZ=`,
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var in, out bytes.Buffer
+
+			in.WriteString(test.input)
+			err := transform(&out, &in, test.vars)
+
+			switch {
+			case err == nil && !test.expectErr:
+				// No error expected, no error returned 👌
+			case err == nil && test.expectErr:
+				t.Errorf("expected error, got none")
+			case err != nil && !test.expectErr:
+				t.Errorf("unexpected error: %s", err.Error())
+			case err != nil && test.expectErr:
+				// Expected error, got one 👌
+			}
+
+			actual := out.String()
+			if actual != test.output {
+				t.Errorf("wrong output: expected %q, got %q", test.output, actual)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -22,5 +22,5 @@ func Print() {
 
 // Fprint writes Clamp's version information to w.
 func Fprint(w io.Writer) {
-	fmt.Fprint(w, "Clamp version %s build %s (at %s)\n", Version, Commit, Date)
+	fmt.Fprintf(w, "Clamp version %s build %s (at %s)\n", Version, Commit, Date)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,11 @@
 package version
 
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
 var (
 	// Version is Clamp's version.
 	Version = "unknown version"
@@ -8,3 +14,13 @@ var (
 	// Date is when Clamp was built.
 	Date = "unknown build date"
 )
+
+// Print writes Clamp's version information to standard output.
+func Print() {
+	Fprint(os.Stdout)
+}
+
+// Fprint writes Clamp's version information to w.
+func Fprint(w io.Writer) {
+	fmt.Fprint(w, "Clamp version %s build %s (at %s)\n", Version, Commit, Date)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,10 @@
+package version
+
+var (
+	// Version is Clamp's version.
+	Version = "unknown version"
+	// Commit is the hash of the commit used to build Clamp.
+	Commit = "unknown commit"
+	// Date is when Clamp was built.
+	Date = "unknown build date"
+)


### PR DESCRIPTION
# Refactor

- Move Clamp's version information to a separate `version` package
- Improve error handling (no more `check` function)
- Inject dependencies into core functions, to improve testability

# Templating function

- Add a `functions` package for custom templating functions
- Add a `required` function based on Helm's implementation

# Unit tests

- Write unit tests for `transform` function
- Write unit tests for `required` templating function