### PR TITLE
feat: add version package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - 386
       - amd64
     ldflags:
-      - -s -w -X github.com/julienbreux/clamp/cmd.version={{.Version}} -X github.com/julienbreux/clamp/cmd.commit={{.Commit}} -X github.com/julienbreux/clamp/cmd.date={{.Date}}
+      - -s -w -X github.com/julienbreux/clamp/version.Version={{.Version}} -X github.com/julienbreux/clamp/version.Commit={{.Commit}} -X github.com/julienbreux/clamp/version.Date={{.Date}}
 archives:
   - id: clamp
     format_overrides:

--- a/main.go
+++ b/main.go
@@ -13,14 +13,11 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/julienbreux/clamp/functions"
+	"github.com/julienbreux/clamp/version"
 )
 
 var (
 	showVersion = false
-
-	version = "dev"
-	commit  = "n/a"
-	date    = "n/a"
 )
 
 func init() {
@@ -31,7 +28,8 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		printVersion()
+		version.Print()
+		return
 	}
 
 	if err := run(); err != nil {
@@ -100,10 +98,4 @@ func envVars() map[string]string {
 		vars[pair[0]] = pair[1]
 	}
 	return vars
-}
-
-func printVersion() {
-	fmt.Printf("Clamp version %s build %s (at %s)\n", version, commit, date)
-
-	os.Exit(0)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -8,11 +8,11 @@ import (
 
 var (
 	// Version is Clamp's version.
-	Version = "unknown version"
+	Version = "dev"
 	// Commit is the hash of the commit used to build Clamp.
-	Commit = "unknown commit"
+	Commit = "n/a"
 	// Date is when Clamp was built.
-	Date = "unknown build date"
+	Date = "n/a"
 )
 
 // Print writes Clamp's version information to standard output.

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var (
+	// Version is Clamp's version.
+	Version = "unknown version"
+	// Commit is the hash of the commit used to build Clamp.
+	Commit = "unknown commit"
+	// Date is when Clamp was built.
+	Date = "unknown build date"
+)
+
+// Print writes Clamp's version information to standard output.
+func Print() {
+	Fprint(os.Stdout)
+}
+
+// Fprint writes Clamp's version information to w.
+func Fprint(w io.Writer) {
+	fmt.Fprintf(w, "Clamp version %s build %s (at %s)\n", Version, Commit, Date)
+}


### PR DESCRIPTION
## Features

- Add a `version` package containing Clamp's version information and helper print functions.