### PR TITLE
fix: exit with code 1 on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "clamp: %s\n", err.Error())
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## Refactor

- Remove usage of `panic`
- Inject dependencies into `transform` function

## Tests

- Add unit tests for `transform` function